### PR TITLE
Modify Orbit versions to conform to Repo version

### DIFF
--- a/components/orbit/gogoproto-java/pom.xml
+++ b/components/orbit/gogoproto-java/pom.xml
@@ -27,7 +27,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gogoproto-java</artifactId>
-    <version>0.1.0-celleryv1</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Cellery Observability Components - Orbit - GoGoProto</name>
 

--- a/components/orbit/grpc/pom.xml
+++ b/components/orbit/grpc/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>grpc</artifactId>
     <packaging>bundle</packaging>
     <name>Cellery Observability Components - Orbit - GRPC</name>
-    <version>1.15.0.celleryv1</version>
+    <version>0.1.0-SNAPSHOT</version>
     <description>This bundle represents io.grpc cellery orbit bundle</description>
 
     <dependencies>
@@ -96,7 +96,7 @@
     </build>
 
     <properties>
-        <grpc.cellery.version>1.15.0-celleryv1</grpc.cellery.version>
+        <grpc.cellery.version>0.1.0-SNAPSHOT</grpc.cellery.version>
     </properties>
 
 

--- a/components/orbit/protobuf/pom.xml
+++ b/components/orbit/protobuf/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>protobuf</artifactId>
     <packaging>bundle</packaging>
     <name>Cellery Observability Components - Orbit - Protobuf</name>
-    <version>3.6.1.celleryv1</version>
+    <version>0.1.0-SNAPSHOT</version>
     <description> This bundle represents com.google.protobuf with gogo.proto.</description>
 
     <dependencies>
@@ -71,7 +71,7 @@
         </plugins>
     </build>
     <properties>
-        <protobuf.cellery.version>3.6.1-celleryv1</protobuf.cellery.version>
+        <protobuf.cellery.version>0.1.0-SNAPSHOT</protobuf.cellery.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -371,9 +371,9 @@
         <bouncy.castle.version>1.59</bouncy.castle.version>
         <opencensus.version>0.16.1</opencensus.version>
 
-        <protobuf.orbit.version>3.6.1.celleryv1</protobuf.orbit.version>
-        <gogoproto.orbit.version>0.1.0-celleryv1</gogoproto.orbit.version>
-        <grpc.orbit.version>1.15.0.celleryv1</grpc.orbit.version>
+        <protobuf.orbit.version>0.1.0-SNAPSHOT</protobuf.orbit.version>
+        <gogoproto.orbit.version>0.1.0-SNAPSHOT</gogoproto.orbit.version>
+        <grpc.orbit.version>0.1.0-SNAPSHOT</grpc.orbit.version>
 
         <spotify.docker.plugin.version>1.4.10</spotify.docker.plugin.version>
 


### PR DESCRIPTION
## Purpose
> The Snapshot Nexus Repository rejects the Orbit Jars if the proper "x.x.x-SNAPSHOT" is not used. Therefore the versions were updated.

## Goals
> Prepare for releases

## Approach
> The versions of the Orbits were updated to match the Repo version

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Apache Maven 3.5.4
> JDK 1.8.0_192
 
## Learning
> N/A